### PR TITLE
Add MixedScene stamp type

### DIFF
--- a/galsim_extra/mixed_scene.py
+++ b/galsim_extra/mixed_scene.py
@@ -1,0 +1,60 @@
+
+import galsim
+
+class MixedSceneBuilder(galsim.config.StampBuilder):
+
+    def setup(self, config, base, xsize, ysize, ignore, logger):
+        # Build all the kinds of objects once to make sure there is something as the
+        # current_val for everything.  Simplifies the ability to get current values of
+        # things in a truth catalog.
+        objects = config['objects']
+        for key in objects:
+            galsim.config.BuildGSObject(base, key)
+
+        # Now go on and do the rest of the normal setup.
+        ignore = ignore + ['objects']
+        return super(self.__class__,self).setup(config,base,xsize,ysize,ignore,logger)
+
+    def buildProfile(self, config, base, psf, gsparams, logger):
+        objects = config['objects']
+        rng = galsim.config.GetRNG(config, base)
+        ud = galsim.UniformDeviate(rng)
+        p = ud()  # A random number between 0 and 1.
+
+        # If the user is careful, this will be 1, but if not, renormalize for them.
+        norm = float(sum(objects.values()))
+
+        # Figure out which object field to use
+        obj_type = None  # So we can check that it was set to something.
+        for key, value in objects.items():
+            p1 = value / norm
+            if p < p1:
+                # Use this object
+                obj_type = key
+                break
+            else:
+                p -= p1
+        if obj_type is None:
+            # This shouldn't happen, but maybe possible from rounding errors.  Use the last one.
+            obj_type = objects.items()[-1][1]
+            logger.error("Error in MixedScene.  Didn't pick an object to use.  Using %s",obj_type)
+        # Save this in the dict so it can be used by e.g. the truth catalog or to do something
+        # different depending on which kind of object we have.
+        base['current_obj_type'] = obj_type
+
+        # Make the appropriate object using the obj_type field
+        obj = galsim.config.BuildGSObject(base, obj_type, gsparams=gsparams, logger=logger)[0]
+        # Also save this in case useful for some calculation.
+        base['current_obj'] = obj
+        if psf:
+            if obj:
+                return galsim.Convolve(obj,psf)
+            else:
+                return psf
+        else:
+            if obj:
+                return obj
+            else:
+                return None
+
+galsim.config.stamp.RegisterStampType('MixedScene', MixedSceneBuilder())


### PR DESCRIPTION
The stamp type MixedScene makes it easier to have a scene with several different kinds of objects in it, each with their own top-level field.  Each kind of object is selected with some probability, given in stamp.objects, and then the selected object type is used the way `gal` is used for the normal stamp type.

For example:
```
modules:
    - galsim_extra

bright_gal:
    # ... some specification for bright galaxies

faint_gal:
    # ... faint galaxies

star:
    # Typically something along the lines of the following:
    type: Gaussian
    sigma: 1.e-6
    flux: 1000

stamp:
    type: MixedScene
    objects:
        # These give the probability of picking each kind of object.
        # The choice of which one is picked for a given object is written to the base dict
        # as base['current_obj_type'] and is thus available as @current_obj_type.
        # The actual constructed object is similarly available as @current_obj
        star: 0.05
        bright_gal: 0.15
        faint_gal: 0.80

    # Can use @current_obj or @current_obj_type in Eval statements.  e.g.
    draw_method: "$'phot' if @current_obj_type == 'faint_gal' or (@current_obj).flux < 1e5 else 'fft'"
```

@esheldon You can take a look at a version of neighbors.yaml that uses this in ~mjarvis/work/neighbors/neighbors.yaml.  To use it, you'll need to re-pull the latest GalSim #865 since I added a feature to the template functionality to make faint_gal pull in the bright_gal dict as a starting point.

This is a bit neater than doing the `index : 0 if p < 0.05 else 1 if p < 0.2 else 2` thing we had been using.