### PR TITLE
Focal plane output type

### DIFF
--- a/examples/exp_list
+++ b/examples/exp_list
@@ -1,0 +1,1 @@
+/Users/Mike/GalSim/examples/des/des_data/ DECam_00154912

--- a/examples/focal.yaml
+++ b/examples/focal.yaml
@@ -235,14 +235,14 @@ image:
         type: RADec
         ra: 
             type: Radians
-            theta: { type: Random, min: "$pointing_minra.rad()", max: "$pointing_maxra.rad()" }
+            theta: { type: Random, min: "$fov_minra.rad()", max: "$fov_maxra.rad()" }
         dec:
             type: Radians
             theta: 
                 type: RandomDistribution
                 function: "math.cos(x)"  # Uniform on the sky means P(delta) ~ cos(delta)
-                x_min: "$pointing_mindec.rad()"
-                x_max: "$pointing_maxdec.rad()"
+                x_min: "$fov_mindec.rad()"
+                x_max: "$fov_maxdec.rad()"
 
     wcs: 
         # Go through the exp_list catalog and sequentially use each exposure once.

--- a/examples/focal.yaml
+++ b/examples/focal.yaml
@@ -1,0 +1,340 @@
+
+# This example config file uses a number of the custom modules available in galsim_extra including
+#     FocalPlane output type
+#     MixedScene stamp type
+#     CosmosR50, CosmosFlux value types along with cosmos_sampler input type
+#     LogNormal value type
+#     OffChip value type
+modules:
+    - galsim_extra
+
+
+# Some variable definitions that let us define things here and then use them again later
+# via either the YAML tag (e.g. *run) or in an eval string (e.g. '$run').
+eval_variables:
+
+    srun: &run "001"
+
+    # These make it easier to include the right value in the truth catalog.
+    fgal_hlr:
+        type: List
+        items:
+        - 0.
+        - '@bright_gal.items.0.half_light_radius'
+        - '@faint_gal.items.0.half_light_radius'
+        - '@nearby_gal.items.0.half_light_radius'
+        index: '@current_obj_type_index'
+
+    fbulge_g1:
+        type: List
+        items:
+        - 0.
+        - '$(@bright_gal.items.0.ellip).g1'
+        - '$(@faint_gal.items.0.ellip).g1'
+        - '$(@nearby_gal.items.0.ellip).g1'
+        index: '@current_obj_type_index'
+
+    fbulge_g2:
+        type: List
+        items:
+        - 0.
+        - '$(@bright_gal.items.0.ellip).g2'
+        - '$(@faint_gal.items.0.ellip).g2'
+        - '$(@nearby_gal.items.0.ellip).g2'
+        index: '@current_obj_type_index'
+
+    fdisk_g1:
+        type: List
+        items:
+        - 0.
+        - '$(@bright_gal.items.1.ellip).g1'
+        - '$(@faint_gal.items.1.ellip).g1'
+        - '$(@nearby_gal.items.1.ellip).g1'
+        index: '@current_obj_type_index'
+
+    fdisk_g2:
+        type: List
+        items:
+        - 0.
+        - '$(@bright_gal.items.1.ellip).g2'
+        - '$(@faint_gal.items.1.ellip).g2'
+        - '$(@nearby_gal.items.1.ellip).g2'
+        index: '@current_obj_type_index'
+
+
+# We have several different kinds of objects that we draw.
+#
+# "Bright" galaxy models are bulge + disk + knots of star formation
+#
+# This follows the model used in Sheldon & Huff 2017
+#
+# The knots are just point sources, distributed according to
+# a random walk
+#
+# All components have the same r50
+#
+# The bulge and disk have independent ellipticities
+# The bulge has g1,g2 scatter of 0.1 (0.2 in eta)
+# The disk  has g1,g2 scatter of 0.2 (0.4 in eta)
+#
+# The knots have the same ellip as the disk
+#
+# The bulge fraction is random, drawn from [0,1]
+# The fraction of the light in the disk is further
+# divided between the smooth component and the knots,
+# also drawn as a fraction between [0,1]
+#
+# The scale radius and flux are drawn jointly from the
+# COSMOS 25.2 limited sample
+bright_gal:
+    type: Sum
+    items:
+        -
+            type: DeVaucouleurs
+            half_light_radius: 
+                type: CosmosR50
+            flux: { type: Random, min: 0, max: 1 }
+            ellip:
+                type: Eta1Eta2
+                # eta ~ 0.2 corresponds to g ~ 0.1
+                eta1: { type: RandomGaussian, sigma: 0.2 }
+                eta2: { type: RandomGaussian, sigma: 0.2 }
+        -
+            type: Exponential
+            half_light_radius: '@bright_gal.items.0.half_light_radius'
+            flux: 
+                type: Eval
+                str: 'smooth_frac * (1. - @bright_gal.items.0.flux)'
+                fsmooth_frac: { type: Random, min: 0, max: 1 }
+            ellip:
+                type: Eta1Eta2
+                # eta ~ 0.4 corresponds to g ~ 0.2
+                eta1: { type: RandomGaussian, sigma: 0.4 }
+                eta2: { type: RandomGaussian, sigma: 0.4 }
+        -
+            type: RandomWalk
+            npoints: 100
+            half_light_radius: '@bright_gal.items.0.half_light_radius'
+            # (relative) flux is 1 - the sum of the other two.
+            ellip: '@bright_gal.items.1.ellip'
+    flux:
+        type: Eval
+        # Scale flux up by a factor of 250
+        str: "250.0 * cosmos_flux"
+        fcosmos_flux: { type: CosmosFlux }
+
+# Faint galaxies use the same population as the bright sample, but scaled
+# to lower flux and size.  This isn't ideal, we end up with extra galaxies
+# where the two populations overlap.
+faint_gal:
+    template: :bright_gal  # Nothing before the : means use a field from the current file
+    scale_flux: 0.1
+    dilate: 0.5
+
+
+# Nearby galaxies are larger and proportionally brighter.
+# We will make this rare as well.
+nearby_gal:
+    template: :bright_gal
+    scale_flux: 25
+    dilate: 5.0
+
+# Stars are basically a delta function, so they end up as just the PSF.
+star:
+    type: Gaussian  # Basically a delta function.
+    sigma: 1.e-6
+    flux:
+        type: RandomDistribution
+        # looks like the slope for the bright end stars in DES r band
+        function: x**-1.5
+        x_min: 1000.0
+        x_max: 1.0e+06
+
+# The PSF is coherent across the full field of view.
+# The size has a polynomial component where it gets larger near the edges to
+# simulate a comatic kind of optical feature.  There is also an atmospheric
+# part using a Gaussian process power spectrum model for the shape and size.
+psf:
+    type: Moffat
+    beta: 2.5
+    fwhm: '$fwhm_central + fwhm_a * (focal_r/focal_rmax)**2'
+    ellip:
+        type: PowerSpectrumShear
+    magnify:
+        type: PowerSpectrumMagnification
+
+stamp:
+    # A custom stamp type in galsim_extra that lets you have multiple kinds of
+    # objects, each with their own base-level field.
+    type: MixedScene
+
+    objects:
+        # These give the probability of picking each kind of object.  The
+        # choice of which one is picked for a given object is written to the
+        # base dict as base['current_obj_type'] and is thus available as
+        # @current_obj_type.  The actual constructed object is similarly
+        # available as @current_obj.  And the type by number in this list
+        # (starting with 0 for the first) is @current_obj_type_index.
+        star:       0.10
+        bright_gal: 0.14
+        nearby_gal: 0.001
+        faint_gal:  0.80
+        # Note: it's fine that these don't add to 1.  They will be renormalized automatically
+
+    draw_method: phot
+
+    shear:
+        type: G1G2
+        g1:
+            type: List
+            items:
+            - 0.        # stars
+            - 0.01      # bright gals
+            - 0.001     # 10x smaller for nearby gals
+            - 0.02      # 2x larger for fainter (more distant) gals
+            index: '@current_obj_type_index'
+        g2: 0.00
+
+    # This is purely for efficiency.  All the objects in the scene are nominally
+    # built for every chip.  That way objects near a chip boundary properly show
+    # up on both chips.  However, if the object is far away from the chip we are
+    # currently working on, this bit skips it right away to save some of the
+    # calculations needed to build the object.
+    skip:
+        type: OffChip
+        # 10*hlr + 10*psf_fwhm is probably conservative as a border...
+        #min_dist: '$10 * gal_hlr + 10 * @psf.fwhm'
+        # But the CosmosR50 calculation is slow.  So instead, just use a constant.
+        # Even though this is less conservative, it's actually faster, since it avoids the slow
+        # hlr calculation for most of the galaxies.
+        min_dist: 100
+
+image:
+    type: Scattered
+
+    noise:
+        type: Poisson
+
+    # Note: The real distribution of sky levels probably isn't flat.  It's probably bimodal,
+    # depending on whether the moon is up.  But this is probably ok for now.
+    sky_level: { type: Random, min: 5000, max: 15000, index_key: exp_num }
+
+    random_seed: 8675309
+
+    # The number of objects across the full focal plane.
+    nobjects:
+        type: RandomPoisson
+        mean: 5.0e5  # Expectation value is half a million objects total ~ 8k per chip
+        index_key: exp_num
+
+    xsize: 2048
+    ysize: 4096
+
+    world_pos:
+        type: RADec
+        ra: 
+            type: Radians
+            theta: { type: Random, min: "$pointing_minra.rad()", max: "$pointing_maxra.rad()" }
+        dec:
+            type: Radians
+            theta: 
+                type: RandomDistribution
+                function: "math.cos(x)"  # Uniform on the sky means P(delta) ~ cos(delta)
+                x_min: "$pointing_mindec.rad()"
+                x_max: "$pointing_maxdec.rad()"
+
+    wcs: 
+        # Go through the exp_list catalog and sequentially use each exposure once.
+        type: Fits
+        dir:
+            type: Catalog
+            col: 0
+        file_name:
+            type: FormattedStr
+            format: "%s_%02d.fits.fz"
+            items:
+            - { type: Catalog, col: 1 }
+            - "$chip_num + 1"
+
+input:
+    # Use analytic galaxies with size and flux parameters that match the distribution seen
+    # in the COSMOS galaxies.
+    cosmos_sampler:
+        min_r50: 0.15
+        max_r50: 1.0
+        min_flux: 2.5
+        max_flux: 100
+
+    power_spectrum: 
+        # Heymans et al, 2012 found L0 ~= 3 arcmin, given as 180 arcsec here.
+        e_power_function: '(k**2 + (1./180)**2)**(-11./6.)'
+        b_power_function: '@input.power_spectrum.e_power_function'
+        units: arcsec
+        grid_spacing: 30
+        variance: '$rms_e**2'  # rms_e is given in meta_params
+
+    catalog:
+        # This catalog has a list of directories and exposure names (the root part before
+        # the _chipnum.fits.fz suffix).
+        # The version of this in the current directory works on my laptop (and just has one
+        # exposure listed).  It would need to be changed to run at scale e.g. at BNL.
+        file_name: exp_list 
+
+meta_params:
+    # This field has information *about* the PSF (or the exposure in general), which will be used
+    # by the psf field to generate the specific PSFs at the location of each galaxy.
+    # This is a custom field for use with the FocalPlane output type.
+    # Variable names here are arbitrary, and will be evaluated once at the start of each
+    # focal plane.  The values can be used by the psf field in eval statements.
+    fwhm_central: { type: LogNormal, mean: 0.9, sigma: 0.1 }
+    fwhm_a: { type: LogNormal, mean: 0.1, sigma: 0.1 }
+    rms_e: 0.03
+
+output:
+    type: FocalPlane
+
+    # The number of exposures to build
+    # Note: the FocalPlane output type adds another available index key, exp_num.  This can
+    # be used as an index_key instead of the usual file_num, image_num, or obj_num.  You can
+    # also access it in eval statements as just exp_num.
+    nexp: '$(@input.catalog).getNObjects()'
+
+    nchips: 62  # The number of chips per exposure
+
+    dir: output
+    file_name:
+        type: FormattedStr
+        format: "sim_%s_%02d.fits.fz"
+        items:
+        - { type: Catalog, col: 1 }
+        - "$chip_num + 1"
+
+    truth:
+        file_name :
+            type: FormattedStr
+            format: "truth_%s_%02d.fits"
+            items:
+            - { type: Catalog, col: 1 }
+            - "$chip_num + 1"
+
+        columns:
+            num: obj_num
+            x: "$image_pos.x"
+            y: "$image_pos.y"
+
+            psf_fwhm: psf.fwhm
+            psf_e1: '$(@psf.ellip).e1'
+            psf_e2: '$(@psf.ellip).e2'
+
+            obj_type: '@current_obj_type'
+            obj_type_index: '@current_obj_type_index'
+            flux: "$(@current_obj).flux"
+            shear_g1: stamp.shear.g1
+            shear_g2: stamp.shear.g2
+
+            gal_hlr: '$gal_hlr'
+            bulge_g1: '$bulge_g1'
+            bulge_g2: '$bulge_g2'
+            disk_g1: '$disk_g1'
+            disk_g2: '$disk_g2'
+

--- a/examples/focal.yaml
+++ b/examples/focal.yaml
@@ -152,7 +152,7 @@ star:
 
 # The PSF is coherent across the full field of view.
 # The size has a polynomial component where it gets larger near the edges to
-# simulate a comatic kind of optical feature.  There is also an atmospheric
+# simulate a defocus kind of optical feature.  There is also an atmospheric
 # part using a Gaussian process power spectrum model for the shape and size.
 psf:
     type: Moffat

--- a/examples/focal.yaml
+++ b/examples/focal.yaml
@@ -202,11 +202,12 @@ stamp:
     # calculations needed to build the object.
     skip:
         type: OffChip
-        # 10*hlr + 10*psf_fwhm is probably conservative as a border...
+        # This is probably conservative as a border:
         #min_dist: '$10 * gal_hlr + 10 * @psf.fwhm'
+
         # But the CosmosR50 calculation is slow.  So instead, just use a constant.
-        # Even though this is less conservative, it's actually faster, since it avoids the slow
-        # hlr calculation for most of the galaxies.
+        # Even though this is even more conservative, it's actually faster, since it avoids the
+        # slow gal_hlr calculation for most of the galaxies.
         min_dist: 100
 
 image:

--- a/galsim_extra/cosmos_sampler.py
+++ b/galsim_extra/cosmos_sampler.py
@@ -130,7 +130,7 @@ def CosmosR50Flux(config, base, name):
     if orig_rng is not None:
         base['rng'] = orig_rng
 
-    return r50, flux
+    return float(r50), float(flux)
 
 
 def CosmosR50(config, base, value_type):

--- a/galsim_extra/focal_plane.py
+++ b/galsim_extra/focal_plane.py
@@ -123,11 +123,11 @@ class FocalPlaneBuilder(OutputBuilder):
         base['eval_variables']['ffocal_ymax'] = bounds.ymax
         rmax = np.max([proj.x**2 + proj.y**2 for proj in proj_list])**0.5
         base['eval_variables']['ffocal_rmax'] = rmax
-        base['pointing'] = pointing
+        base['eval_variables']['xpointing'] = pointing
         base['eval_variables']['ffocal_r'] = {
             'type' : 'Eval',
             'str' : "math.sqrt(pos.x**2 + pos.y**2)",
-            'ppos' : "$base['pointing'].project(@image.world_pos)"
+            'ppos' : "$pointing.project(@image.world_pos)"
         }
 
         # Evaluate all the meta parameters and write them into the eval_variables dict.
@@ -239,6 +239,13 @@ class FocalPlaneBuilder(OutputBuilder):
         if 'nchips' not in config:
             raise AttributeError("Attribute output.nchips is required for output.type = FocalPlane")
         return galsim.config.ParseValue(config,'nchips',base,int)[0]
+
+    # Both of these steps will already have been done by the Fits builder.  Don't do anything here.
+    def addExtraOutputHDUs(self, config, data, logger):
+        return data
+
+    def writeExtraOutputs(self, config, data, logger):
+        pass
 
 galsim.config.process.top_level_fields += ['meta_params']
 galsim.config.output.RegisterOutputType('FocalPlane', FocalPlaneBuilder())

--- a/galsim_extra/focal_plane.py
+++ b/galsim_extra/focal_plane.py
@@ -1,0 +1,244 @@
+
+import galsim
+import os
+import numpy as np
+
+from galsim.config.output import OutputBuilder
+
+class FocalPlaneBuilder(OutputBuilder):
+    """Implements the FocalPlane custom output type.
+
+    This type models a full focal plane including multiple CCD images using coherent patterns
+    for things like the PSF and sky level.
+
+    The wcs is taken from a reference wcs (e.g. from a set of Fits files), but can reset the
+    pointing position to a different location on the sky.
+    """
+
+    def getNFiles(self, config, base):
+        """Returns the number of files to be built.
+
+        As far as the config processing is concerned, this is the number of times it needs
+        to call buildImages, regardless of how many physical files are actually written to
+        disk.  So this corresponds to output.nexp for the FocalPlane output type.
+
+        @param config           The configuration dict for the output field.
+        @param base             The base configuration dict.
+
+        @returns the number of "files" to build.
+        """
+        # This is the first function from the OutputBuilder that gets called, so this is the
+        # earliest that we get add this to the list of valid index keys.
+        if 'exp_num' not in galsim.config.process.valid_index_keys:
+            galsim.config.process.valid_index_keys += ['exp_num']
+        if 'nexp' in config:
+            try:
+                return galsim.config.ParseValue(config, 'nexp', base, int)[0]
+            except:
+                galsim.config.ProcessInput(base)
+                return galsim.config.ParseValue(config, 'nexp', base, int)[0]
+        else:
+            return 1
+
+    def buildImages(self, config, base, file_num, image_num, obj_num, ignore, logger):
+        """Build the images
+
+        @param config           The configuration dict for the output field.
+        @param base             The base configuration dict.
+        @param file_num         The current file_num.
+        @param image_num        The current image_num.
+        @param obj_num          The current obj_num.
+        @param ignore           A list of parameters that are allowed to be in config that we can
+                                ignore here.  i.e. it won't be an error if they are present.
+        @param logger           If given, a logger object to log progress.
+
+        @returns a list of the images built
+        """
+        req = { 'nchips' : int, }
+        opt = { 'nexp' : int, }
+        ignore += [ 'file_name', 'dir' ]
+
+        kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt, ignore=ignore)
+
+        nchips = kwargs['nchips']
+        nexp = kwargs.get('nchips',1)
+
+        if 'eval_variables' not in base:
+            base['eval_variables'] = {}
+        base['eval_variables']['iexp_num'] = file_num
+
+        # Get the celestial coordinates of all the chip corners
+        corners = []
+        for chip_num in range(nchips):
+            # Set the chip num in case needed for parsing values.
+            base['chip_num'] = chip_num
+            base['eval_variables']['ichip_num'] = chip_num
+            base['image_num'] = image_num + chip_num
+
+            wcs = galsim.config.wcs.BuildWCS(base['image'],'wcs', base)
+            xsize = galsim.config.ParseValue(base['image'],'xsize', base, int)[0]
+            ysize = galsim.config.ParseValue(base['image'],'ysize', base, int)[0]
+
+            im_pos1 = galsim.PositionD(0,0)
+            im_pos2 = galsim.PositionD(0,ysize)
+            im_pos3 = galsim.PositionD(xsize,0)
+            im_pos4 = galsim.PositionD(xsize,ysize)
+            corners.append(wcs.toWorld(im_pos1))
+            corners.append(wcs.toWorld(im_pos2))
+            corners.append(wcs.toWorld(im_pos3))
+            corners.append(wcs.toWorld(im_pos4))
+
+        # Calculate the pointing as the center (mean) of all the position in corners
+        x_list, y_list, z_list = zip(*[p.get_xyz() for p in corners])
+        pointing_x = np.mean(x_list)
+        pointing_y = np.mean(y_list)
+        pointing_z = np.mean(z_list)
+        pointing = galsim.CelestialCoord.from_xyz(pointing_x, pointing_y, pointing_z)
+
+        # Also calculate the min/max ra and dec
+        ra_list = [p.ra.wrap(pointing.ra.rad()) for p in corners]
+        dec_list = [p.dec for p in corners]
+        pointing_minra = np.min(ra_list)
+        pointing_maxra = np.max(ra_list)
+        pointing_mindec = np.min(dec_list)
+        pointing_maxdec = np.max(dec_list)
+
+        # bounds is the bounds in the tangent plane
+        proj_list = [ pointing.project(p, projection='gnomonic') for p in corners]
+        bounds = galsim.BoundsD()
+        for proj in proj_list: bounds += proj
+
+        # Write these values into the dict in eval_variables, so they can be used in Eval's.
+        base['eval_variables']['apointing_ra'] = pointing.ra
+        base['eval_variables']['apointing_dec'] = pointing.dec
+        base['eval_variables']['apointing_minra'] = pointing_minra
+        base['eval_variables']['apointing_maxra'] = pointing_maxra
+        base['eval_variables']['apointing_mindec'] = pointing_mindec
+        base['eval_variables']['apointing_maxdec'] = pointing_maxdec
+        base['eval_variables']['ifirst_image_num'] = image_num
+        base['eval_variables']['ichip_num'] = '$image_num - first_image_num'
+        base['eval_variables']['ffocal_xmin'] = bounds.xmin
+        base['eval_variables']['ffocal_xmax'] = bounds.xmax
+        base['eval_variables']['ffocal_ymin'] = bounds.ymin
+        base['eval_variables']['ffocal_ymax'] = bounds.ymax
+        rmax = np.max([proj.x**2 + proj.y**2 for proj in proj_list])**0.5
+        base['eval_variables']['ffocal_rmax'] = rmax
+        base['pointing'] = pointing
+        base['eval_variables']['ffocal_r'] = {
+            'type' : 'Eval',
+            'str' : "math.sqrt(pos.x**2 + pos.y**2)",
+            'ppos' : "$base['pointing'].project(@image.world_pos)"
+        }
+
+        # Evaluate all the meta parameters and write them into the eval_variables dict.
+        if 'meta_params' in base:
+            for key in base['meta_params']:
+                param = galsim.config.ParseValue(base['meta_params'], key, base, float)[0]
+                base['eval_variables']['f' + key] = param
+
+        # Set the random numbers to repeat for the objects so we get the same objects in the field
+        # each time.
+        rs = base['image']['random_seed']
+        if not isinstance(rs,list):
+            nobjects = galsim.config.GetCurrentValue('image.nobjects', base, int)
+            first = galsim.config.ParseValue(base['image'], 'random_seed', base, int)[0]
+            base['image']['random_seed'] = [
+                {  # Used for most things.  Repeats for each chip.
+                    'type' : 'Eval',
+                    'str' : 'first_seed + obj_num % @image.nobjects',
+                    'ifirst_seed' : '$%d + file_num * @image.nobjects'%first
+                }
+            ]
+            # The second one is the original random_seed specification,  used for noise, since
+            # that should be different on each chip.
+            if isinstance(rs,int):
+                base['image']['random_seed'].append(
+                    { 'type' : 'Sequence', 'index_key' : 'obj_num', 'first' : first } )
+            else:
+                base['image']['random_seed'].append(rs)
+            base['image']['noise']['rng_num'] = 1
+
+        # We let GalSim do its normal BuildFiles thing now, which would run in parallel
+        # if appropriate.  And it writes each image to disk as it gets made rather than holding
+        # the full exposure in memory before writing anything.  So copy over the current
+        # config into a new dict and make appropriate adjustments to make it work.
+        simple_config = {}
+        simple_config.update(config)
+        simple_config['nfiles'] = config['nchips']
+        simple_config['type'] = 'Fits'
+        base['output'] = simple_config
+        if 'nproc' in base['image']:
+            simple_config['nproc'] = base['image']['nproc']
+        base['exp_num'] = base['file_num']
+
+        if 'nexp' not in galsim.config.output.output_ignore:
+            galsim.config.output.output_ignore += ['nexp', 'nchips']
+
+        galsim.config.BuildFiles(nchips, base, file_num, logger=logger)
+
+        # Go back to the original dict.
+        base['output'] = config
+
+        # The calling function is expecting to get some images to write.  Give it something
+        # to avoid errors, but we won't write these.
+        return [galsim.Image()] * nchips
+
+    def getFilename(self, config, base, logger):
+        """Get the file_name for the current file being worked on.
+
+        Note that the base class defines a default extension = '.fits'.
+        This can be overridden by subclasses by changing the default_ext property.
+
+        @param config           The configuration dict for the output type.
+        @param base             The base configuration dict.
+        @param image_num        The current image_num.
+        @param obj_num          The current obj_num.
+        @param ignore           A list of parameters that are allowed to be in config['output']
+                                that we can ignore here.  i.e. it won't be an error if these
+                                parameters are present.
+        @param logger           If given, a logger object to log progress.
+
+        @returns the filename to build.
+        """
+        # Typically, the filename will depend on the chip_num, but if this gets called before
+        # buildImages, then it won't be ready, so just check.
+        if 'eval_variables' not in base:
+            base['eval_variables'] = {}
+        if 'ichip_num' not in base['eval_variables']:
+            base['eval_variables']['ichip_num'] = 0
+        if 'iexp_num' not in base['eval_variables']:
+            base['eval_variables']['iexp_num'] = base['file_num']
+        if 'exp_num' not in base:
+            base['exp_num'] = base['file_num']
+        return super(FocalPlaneBuilder, self).getFilename(config, base, logger)
+
+    def writeFile(self, data, file_name, config, base, logger):
+        """Write the data to a file.
+
+        @param data             The data to write.  Usually a list of images returned by
+                                buildImages, but possibly with extra HDUs tacked onto the end
+                                from the extra output items.
+        @param file_name        The file_name to write to.
+        @param config           The configuration dict for the output field.
+        @param base             The base configuration dict.
+        @param logger           If given, a logger object to log progress.
+        """
+        # These were already written during the BuildImages call, so don't do anything here.
+        return
+
+    def getNImages(self, config, base, file_num):
+        """
+        Get the number of images for a FocalPlane output type.
+
+        @param config           The configuration dict for the output field.
+        @param base             The base configuration dict.
+        @param file_num         The current file number.
+
+        @returns the number of images
+        """
+        if 'nchips' not in config:
+            raise AttributeError("Attribute output.nchips is required for output.type = FocalPlane")
+        return galsim.config.ParseValue(config,'nchips',base,int)[0]
+
+galsim.config.process.top_level_fields += ['meta_params']
+galsim.config.output.RegisterOutputType('FocalPlane', FocalPlaneBuilder())

--- a/galsim_extra/focal_plane.py
+++ b/galsim_extra/focal_plane.py
@@ -98,10 +98,10 @@ class FocalPlaneBuilder(OutputBuilder):
         # Also calculate the min/max ra and dec
         ra_list = [p.ra.wrap(pointing.ra.rad()) for p in corners]
         dec_list = [p.dec for p in corners]
-        pointing_minra = np.min(ra_list)
-        pointing_maxra = np.max(ra_list)
-        pointing_mindec = np.min(dec_list)
-        pointing_maxdec = np.max(dec_list)
+        fov_minra = np.min(ra_list)
+        fov_maxra = np.max(ra_list)
+        fov_mindec = np.min(dec_list)
+        fov_maxdec = np.max(dec_list)
 
         # bounds is the bounds in the tangent plane
         proj_list = [ pointing.project(p, projection='gnomonic') for p in corners]
@@ -111,10 +111,10 @@ class FocalPlaneBuilder(OutputBuilder):
         # Write these values into the dict in eval_variables, so they can be used in Eval's.
         base['eval_variables']['apointing_ra'] = pointing.ra
         base['eval_variables']['apointing_dec'] = pointing.dec
-        base['eval_variables']['apointing_minra'] = pointing_minra
-        base['eval_variables']['apointing_maxra'] = pointing_maxra
-        base['eval_variables']['apointing_mindec'] = pointing_mindec
-        base['eval_variables']['apointing_maxdec'] = pointing_maxdec
+        base['eval_variables']['afov_minra'] = fov_minra
+        base['eval_variables']['afov_maxra'] = fov_maxra
+        base['eval_variables']['afov_mindec'] = fov_mindec
+        base['eval_variables']['afov_maxdec'] = fov_maxdec
         base['eval_variables']['ifirst_image_num'] = image_num
         base['eval_variables']['ichip_num'] = '$image_num - first_image_num'
         base['eval_variables']['ffocal_xmin'] = bounds.xmin

--- a/galsim_extra/mixed_scene.py
+++ b/galsim_extra/mixed_scene.py
@@ -4,15 +4,9 @@ import galsim
 class MixedSceneBuilder(galsim.config.StampBuilder):
 
     def setup(self, config, base, xsize, ysize, ignore, logger):
-        # Add objects field to the ignore list
-        # Also ignore magnify and shear, which we allow here for convenience to act on whichever
-        # object ends up being chosen.
-        ignore = ignore + [ 'objects', 'magnify', 'shear' ]
+        if 'objects' not in config:
+            raise AttributeError('objets field is required for MixedScene stamp type')
 
-        # Now go on and do the rest of the normal setup.
-        return super(self.__class__,self).setup(config,base,xsize,ysize,ignore,logger)
-
-    def buildProfile(self, config, base, psf, gsparams, logger):
         objects = config['objects']
         rng = galsim.config.GetRNG(config, base)
         ud = galsim.UniformDeviate(rng)
@@ -42,6 +36,18 @@ class MixedSceneBuilder(galsim.config.StampBuilder):
         # different depending on which kind of object we have.
         base['current_obj_type'] = obj_type
         base['current_obj_type_index'] = obj_type_index
+        base['current_obj'] = None
+
+        # Add objects field to the ignore list
+        # Also ignore magnify and shear, which we allow here for convenience to act on whichever
+        # object ends up being chosen.
+        ignore = ignore + ['objects', 'magnify', 'shear']
+
+        # Now go on and do the rest of the normal setup.
+        return super(self.__class__,self).setup(config,base,xsize,ysize,ignore,logger)
+
+    def buildProfile(self, config, base, psf, gsparams, logger):
+        obj_type = base['current_obj_type']
 
         # Make the appropriate object using the obj_type field
         obj = galsim.config.BuildGSObject(base, obj_type, gsparams=gsparams, logger=logger)[0]

--- a/galsim_extra/mixed_scene.py
+++ b/galsim_extra/mixed_scene.py
@@ -23,6 +23,7 @@ class MixedSceneBuilder(galsim.config.StampBuilder):
 
         # Figure out which object field to use
         obj_type = None  # So we can check that it was set to something.
+        obj_type_index = 0
         for key, value in objects.items():
             p1 = value / norm
             if p < p1:
@@ -31,13 +32,16 @@ class MixedSceneBuilder(galsim.config.StampBuilder):
                 break
             else:
                 p -= p1
+                obj_type_index += 1
         if obj_type is None:
             # This shouldn't happen, but maybe possible from rounding errors.  Use the last one.
             obj_type = objects.items()[-1][1]
+            obj_type_index -= 1
             logger.error("Error in MixedScene.  Didn't pick an object to use.  Using %s",obj_type)
         # Save this in the dict so it can be used by e.g. the truth catalog or to do something
         # different depending on which kind of object we have.
         base['current_obj_type'] = obj_type
+        base['current_obj_type_index'] = obj_type_index
 
         # Make the appropriate object using the obj_type field
         obj = galsim.config.BuildGSObject(base, obj_type, gsparams=gsparams, logger=logger)[0]

--- a/galsim_extra/mixed_scene.py
+++ b/galsim_extra/mixed_scene.py
@@ -4,15 +4,12 @@ import galsim
 class MixedSceneBuilder(galsim.config.StampBuilder):
 
     def setup(self, config, base, xsize, ysize, ignore, logger):
-        # Build all the kinds of objects once to make sure there is something as the
-        # current_val for everything.  Simplifies the ability to get current values of
-        # things in a truth catalog.
-        objects = config['objects']
-        for key in objects:
-            galsim.config.BuildGSObject(base, key)
+        # Add objects field to the ignore list
+        # Also ignore magnify and shear, which we allow here for convenience to act on whichever
+        # object ends up being chosen.
+        ignore = ignore + [ 'objects', 'magnify', 'shear' ]
 
         # Now go on and do the rest of the normal setup.
-        ignore = ignore + ['objects']
         return super(self.__class__,self).setup(config,base,xsize,ysize,ignore,logger)
 
     def buildProfile(self, config, base, psf, gsparams, logger):
@@ -46,6 +43,11 @@ class MixedSceneBuilder(galsim.config.StampBuilder):
         obj = galsim.config.BuildGSObject(base, obj_type, gsparams=gsparams, logger=logger)[0]
         # Also save this in case useful for some calculation.
         base['current_obj'] = obj
+
+        # Only shear and magnify are allowed, but this general TransformObject function will
+        # work to implement those.
+        obj, safe = galsim.config.TransformObject(obj, config, base, logger)
+
         if psf:
             if obj:
                 return galsim.Convolve(obj,psf)

--- a/galsim_extra/off_chip.py
+++ b/galsim_extra/off_chip.py
@@ -1,0 +1,17 @@
+import galsim
+import math
+
+def OffChip(config, base, value_type):
+    """See if an object should be skipped because it is too far off the edge of a chip
+    """
+    pos = base['stamp_center']
+    bounds = base['current_image'].bounds
+    min_dist = galsim.config.ParseValue(config,'min_dist',base,float)[0]
+    # Round up to an integer
+    min_dist = int(math.ceil(min_dist))
+
+    bounds = bounds.withBorder(min_dist)
+    return not bounds.includes(pos)
+
+galsim.config.RegisterValueType('OffChip', OffChip, [ bool ])
+


### PR DESCRIPTION
I think I've finally finished up the hack week project that @NiallMac and I were doing at the [LSST meeting](https://confluence.slac.stanford.edu/display/LSSTDESC/SLAC+2017+-+Friday+Hack+Day) in February:
> We plan to implement a module for use in a GalSim config file to generate all the individual CCD images in a full exposure using coherent PSF, noise, etc. properties across the field of view.  The specific implementation will be for a DECam focal plane, but the basic code will be relevant for simulating LSST focal planes (or HSC, etc.) as well.

On the actual hack day, we ran into a number of issues where the config apparatus wasn't able to easily handle some of the things we wanted to do.  So we *hacked* some work-arounds at the time, but we still unfortunately didn't manage to get something working by the end of the day.  

Since then, I've taken a step back and worked on making the GalSim config code actually do the things that we wished it was able to do.  These are in [PR now on branch #865](https://github.com/GalSim-developers/GalSim/pull/872).  And I kept working on the focal plane code here, implementing and testing the new config features.

I think the `FocalPlane` module now does everything we wanted.  There is an [example config file](https://github.com/esheldon/galsim_extra/blob/focal_plane/examples/focal.yaml), which is probably the easiest way to review the capabilities of this module.  
- It generates meta parameters (in the `meta_params` field) which are generated once per exposure, but then used for each chip in that exposure.  
- The PSF is generated from a power spectrum realization of the sky, so it is coherent across the field of view.  
- There is also a kind of defocus component to the size where it gets larger near the edges simulating a non-flat focal plane.
- The scene includes stars, bright galaxies (from cosmos), faint galaxies (scaled down from cosmos) and nearby galaxies (scaled up from cosmos).  This is based on a simulation that @esheldon and I designed to test neighbors, but it seemed appropriate here as well as an example of the MixedScene stamp type that is already in this repo (although I modified is slightly here).
- Before building the images, the FocalPlane code checks the wcs of each image that it is going to build and calculates some summary information like `pointing_ra`, `pointing_dec` (the sky position of the center of the field of view) and `fov_minra`, `fov_maxra`, `fov_mindec`, `fov_maxdec` (the min/max coordinates in the field of view).  You can see the latter values used in the `world_pos` field to select random locations within the field of view.
- The code runs through all O(half a million) objects (stars and galaxies) for each chip, only drawing the ones that actually overlap the chip, at least partially.  To make that not take forever, I added an OffChip calculation that allows it to quickly skip an object if it is more than a certain distance (`min_dist`) off the edge of the current image.  So most objects are immediately skipped without further calculation.
- It's still not super fast, but not too terrible.  It takes about 5 min per chip doing 62 DECam chips.  Given that this is ~500,000 galaxies, that comes out to about 0.03 sec/gal.  Most of that time is actually spent parsing the config dict and building the objects, rather than drawing, since all the profiles are analytic, most objects are very faint, and they are being photon shot, so that's really quick.  One of the tall poles is doing the kde sampling for the COSMOS size/flux joint distribution (using the `cosmos_sampler` module also in this repo).  So there might be some useful optimization to do to speed that up.

Finally, Niall and I were originally working on this on an [LSST repo](https://github.com/LSSTDESC/GalsimModules), since it was nominally an LSST hack.  But since the end result isn't really LSST-specific, I'm submitting it here instead.  Pinging watchers of that page in case you are interested: (@drphilmarshall @connolly @richardxdubois @tony-johnson @jchiang87).  I do think it would be useful to modify this module a bit to make it LSST specific (e.g. adding in the sensor effects and Jim's readout chain) and host it there, but I haven't done so yet.
