### PR TITLE
use MixedSceneBuilder instead of self.__class__ in super

### DIFF
--- a/galsim_extra/mixed_scene.py
+++ b/galsim_extra/mixed_scene.py
@@ -54,7 +54,7 @@ class MixedSceneBuilder(galsim.config.StampBuilder):
         ignore = ignore + ['objects', 'magnify', 'shear']
 
         # Now go on and do the rest of the normal setup.
-        return super(self.__class__,self).setup(config,base,xsize,ysize,ignore,logger)
+        return super(MixedSceneBuilder, self).setup(config,base,xsize,ysize,ignore,logger)
 
     def buildProfile(self, config, base, psf, gsparams, logger):
         obj_type = base['current_obj_type']


### PR DESCRIPTION
The usage of super used before this change: `super(self.__class__,self).setup(...)` seems to cause a `RuntimeError: maximum recursion depth exceeded` error for subclasses of `MixedSceneBuilder`. I've changed this to `super(MixedSceneBuilder,self).setup(...)`, which seems to avoid this error (and is the usage of super I'm more familiar with).