### PR TITLE
Add WideScattered image type

### DIFF
--- a/galsim_extra/focal_plane.py
+++ b/galsim_extra/focal_plane.py
@@ -162,6 +162,7 @@ class FocalPlaneBuilder(OutputBuilder):
 
         exp_num = base['exp_num']
         chip_num = base['chip_num']
+        first_chip_num = base['chip_num']
         req = { 'nchips' : int, }
         opt = { 'nexp' : int, }
         ignore += [ 'file_name', 'dir' ]
@@ -178,6 +179,7 @@ class FocalPlaneBuilder(OutputBuilder):
             # Get the celestial coordinates of all the chip corners
             corners = []
             for chip_num in range(nchips):
+                base['chip_num'] = chip_num
                 wcs = galsim.config.wcs.BuildWCS(base['image'],'wcs', base, logger)
                 if not wcs.isCelestial():
                     raise ValueError("FocalPlane requires a CelestialWCS")
@@ -192,6 +194,9 @@ class FocalPlaneBuilder(OutputBuilder):
                 corners.append(wcs.toWorld(im_pos2))
                 corners.append(wcs.toWorld(im_pos3))
                 corners.append(wcs.toWorld(im_pos4))
+                logger.debug("corners of chip %d = %s",chip_num, [c.rad for c in corners[-4:]])
+
+            chip_num = base['chip_num'] = first_chip_num
 
             # Calculate the pointing as the center (mean) of all the position in corners
             x_list, y_list, z_list = zip(*[p.get_xyz() for p in corners])

--- a/galsim_extra/focal_plane.py
+++ b/galsim_extra/focal_plane.py
@@ -202,19 +202,20 @@ class FocalPlaneBuilder(OutputBuilder):
             logger.info("Calculated center of focal plane to be %s",pointing)
 
             # Also calculate the min/max ra and dec
-            ra_list = [p.ra.wrap(pointing.ra) for p in corners]
-            dec_list = [p.dec for p in corners]
+            ra_list = [p.ra.wrap(pointing.ra) / galsim.degrees for p in corners]
+            dec_list = [p.dec / galsim.degrees for p in corners]
             fov_minra = np.min(ra_list)
             fov_maxra = np.max(ra_list)
             fov_mindec = np.min(dec_list)
             fov_maxdec = np.max(dec_list)
-            logger.info("RA range = %.2f - %.2f deg",
-                        fov_minra/galsim.degrees, fov_maxra/galsim.degrees)
-            logger.info("Dec range = %.2f - %.2f deg",
-                        fov_mindec/galsim.degrees, fov_maxdec/galsim.degrees)
+            logger.info("RA range = %.2f - %.2f deg", fov_minra, fov_maxra)
+            logger.info("Dec range = %.2f - %.2f deg", fov_mindec, fov_maxdec)
 
             # bounds is the bounds in the tangent plane
             proj_list = [ pointing.project(p, projection='gnomonic') for p in corners]
+            # Convert Angle tuples into PositionD in arcsec
+            proj_list = [ galsim.PositionD(p[0]/galsim.arcsec, p[1]/galsim.arcsec)
+                            for p in proj_list ]
             bounds = galsim.BoundsD()
             for proj in proj_list: bounds += proj
             logger.info("Bounds in tangent plane = %s (arcsec)",bounds)
@@ -222,10 +223,10 @@ class FocalPlaneBuilder(OutputBuilder):
             # Write these values into the dict in eval_variables, so they can be used in Eval's.
             base['eval_variables']['aworld_center_ra'] = pointing.ra
             base['eval_variables']['aworld_center_dec'] = pointing.dec
-            base['eval_variables']['afov_minra'] = fov_minra
-            base['eval_variables']['afov_maxra'] = fov_maxra
-            base['eval_variables']['afov_mindec'] = fov_mindec
-            base['eval_variables']['afov_maxdec'] = fov_maxdec
+            base['eval_variables']['afov_minra'] = fov_minra * galsim.degrees
+            base['eval_variables']['afov_maxra'] = fov_maxra * galsim.degrees
+            base['eval_variables']['afov_mindec'] = fov_mindec * galsim.degrees
+            base['eval_variables']['afov_maxdec'] = fov_maxdec * galsim.degrees
             base['eval_variables']['ifirst_image_num'] = image_num
             base['eval_variables']['ffocal_xmin'] = bounds.xmin
             base['eval_variables']['ffocal_xmax'] = bounds.xmax

--- a/galsim_extra/mixed_scene.py
+++ b/galsim_extra/mixed_scene.py
@@ -25,23 +25,28 @@ class MixedSceneBuilder(galsim.config.StampBuilder):
         # If the user is careful, this will be 1, but if not, renormalize for them.
         norm = float(sum(objects.values()))
 
-        # Figure out which object field to use
-        obj_type = None  # So we can check that it was set to something.
-        obj_type_index = 0
-        for key, value in objects.items():
-            p1 = value / norm
-            if p < p1:
-                # Use this object
-                obj_type = key
-                break
-            else:
-                p -= p1
-                obj_type_index += 1
-        if obj_type is None:
-            # This shouldn't happen, but maybe possible from rounding errors.  Use the last one.
-            obj_type = objects.items()[-1][1]
-            obj_type_index -= 1
-            logger.error("Error in MixedScene.  Didn't pick an object to use.  Using %s",obj_type)
+        if 'obj_type' in config:
+            obj_type = galsim.config.ParseValue(config, 'obj_type', base, str)[0]
+            obj_type_index = list(objects.keys()).index(obj_type)
+        else:
+            # Figure out which object field to use
+            obj_type = None  # So we can check that it was set to something.
+            obj_type_index = 0
+            for key, value in objects.items():
+                p1 = value / norm
+                if p < p1:
+                    # Use this object
+                    obj_type = key
+                    break
+                else:
+                    p -= p1
+                    obj_type_index += 1
+            if obj_type is None:
+                # This shouldn't happen, but maybe possible from rounding errors.  Use the last one.
+                obj_type = list(objects.keys())[-1]
+                obj_type_index -= 1
+                logger.error("Error in MixedScene.  Didn't pick an object to use.  Using %s",obj_type)
+
         # Save this in the dict so it can be used by e.g. the truth catalog or to do something
         # different depending on which kind of object we have.
         base['current_obj_type'] = obj_type
@@ -51,7 +56,7 @@ class MixedSceneBuilder(galsim.config.StampBuilder):
         # Add objects field to the ignore list
         # Also ignore magnify and shear, which we allow here for convenience to act on whichever
         # object ends up being chosen.
-        ignore = ignore + ['objects', 'magnify', 'shear']
+        ignore = ignore + ['objects', 'magnify', 'shear', 'obj_type']
 
         # Now go on and do the rest of the normal setup.
         return super(MixedSceneBuilder, self).setup(config,base,xsize,ysize,ignore,logger)

--- a/galsim_extra/postop_stamp.py
+++ b/galsim_extra/postop_stamp.py
@@ -11,13 +11,13 @@ class PostOpStampBuilder(StampBuilder):
         ignore = ignore + [
             'dilate', 'dilation', 'ellip', 'rotate', 'rotation', 'scale_flux',
             'magnify', 'magnification', 'shear', 'shift' ]
-        return super(self.__class__,self).setup(config,base,xsize,ysize,ignore,logger)
+        return super(PostOpStampBuilder,self).setup(config,base,xsize,ysize,ignore,logger)
 
     def buildProfile(self, config, base, psf, gsparams, logger):
         # Change the psf appropriately
         psf, safe = TransformObject(psf, config, base, logger)
         # Then call the normal buildProfile with the new psf object.
-        return super(self.__class__,self).buildProfile(config, base, psf, gsparams, logger)
+        return super(PostOpStampBuilder,self).buildProfile(config, base, psf, gsparams, logger)
 
 RegisterStampType('PostOp', PostOpStampBuilder())
 

--- a/galsim_extra/wide_scattered.py
+++ b/galsim_extra/wide_scattered.py
@@ -1,0 +1,210 @@
+#
+# This module is a very simple modification of the normal Scattered image type.
+# After building the image the normal way, just before it writes out the image to disk,
+# it slaps on a different wcs.
+
+import galsim
+import coord
+import numpy as np
+
+class WideScatteredBuilder(galsim.config.image_scattered.ScatteredImageBuilder):
+
+    def setup(self, config, base, image_num, obj_num, ignore, logger):
+        ignore = ignore + ['border']
+        return super(WideScatteredBuilder, self).setup(config, base, image_num, obj_num, ignore, logger)
+
+    def buildImage(self, config, base, image_num, obj_num, logger):
+        # Copy the Scattered buildImage function, but with changes to skip building stamps that
+        # are clearly not in the image.
+
+        print('start buildImage')
+        xsize = base['image_xsize']
+        ysize = base['image_ysize']
+        wcs = base['wcs']
+
+        image = galsim.ImageF(xsize, ysize)
+        image.setOrigin(base['image_origin'])
+        image.wcs = wcs
+        image.setZero()
+        base['current_image'] = image
+
+        # Note: I'm hard-coding this to take in world_pos.  I think this is the only way this
+        # class is useful, so that should be fine.  But make sure the config isn't giving
+        # image_pos directly.
+        if 'image_pos' in config or 'world_pos' not in config:
+            raise galsim.GalSimConfigValueError(
+                "WideScattered requires positions to be given by world_pos")
+
+        # The border in arcsec within which we use the normal skip functionality that creates
+        # the stamp for the object to see if there is any overlap on the full image.
+        # Things outside this border are skipped before even getting to the StampBuilder.
+        if 'border' in config:
+            border = galsim.config.ParseValue(config, 'border', base, float)[0]
+        else:
+            border = 60  # default = 1 arcmin
+
+        # Note: I'm hard-coding this to celestial coordinates.  So just raise an exception if
+        # someone does this with a EuclideanWCS
+        assert wcs.isCelestial()
+
+        # Find the bounding polynomial in ra, dec.
+        # Note: a rectangle in image coordinates is not necessarily a rectangle in ra, dec,
+        # since it could be rotated.  Also, it's slightly a trapezoid because of the cos(dec)
+        # factor along the ra direction, even if telescope is equitoral mount.
+        ll = wcs.toWorld(galsim.PositionD(image.xmin, image.ymin))  # lower-left
+        ul = wcs.toWorld(galsim.PositionD(image.xmin, image.ymax))  # upper-left
+        lr = wcs.toWorld(galsim.PositionD(image.xmax, image.ymin))  # lower-right
+        ur = wcs.toWorld(galsim.PositionD(image.xmax, image.ymax))  # upper-right
+        cen = wcs.toWorld(image.true_center)
+        print('ll = ',ll)
+        print('ul = ',ul)
+        print('lr = ',lr)
+        print('ur = ',ur)
+
+        # Push all the corners out by a distance of border
+        ll = ll.greatCirclePoint(cen, -border * coord.arcsec)
+        ul = ul.greatCirclePoint(cen, -border * coord.arcsec)
+        lr = lr.greatCirclePoint(cen, -border * coord.arcsec)
+        ur = ur.greatCirclePoint(cen, -border * coord.arcsec)
+        print('ll => ',ll)
+        print('ul => ',ul)
+        print('lr => ',lr)
+        print('ur => ',ur)
+
+        # Directed edges going around the perimeter
+        edges = ( (ll,ul), (ul,ur), (ur,lr), (lr,ll) )
+
+        # Find the simple bounding box for trivial rejections
+        min_ra = min([ll.ra.deg, ul.ra.deg, lr.ra.deg, ur.ra.deg])
+        max_ra = max([ll.ra.deg, ul.ra.deg, lr.ra.deg, ur.ra.deg])
+        min_dec = min([ll.dec.deg, ul.dec.deg, lr.dec.deg, ur.dec.deg])
+        max_dec = max([ll.dec.deg, ul.dec.deg, lr.dec.deg, ur.dec.deg])
+        print('ra range = ',min_ra,max_ra)
+        print('dec range = ',min_dec,max_dec)
+
+        # Set up rng.
+        # Note: This uses the rng of the first object.  Not switching each time.
+        # I think that's preferable so we don't get dominated by rng setup for each object.
+        # But it means that we need to write stamp.world_pos as a list of these values.
+        base['index_key'] = 'obj_num'
+        seed = galsim.config.SetupConfigRNG(base, seed_offset=1, logger=logger)
+        logger.debug('obj %d: seed = %d',obj_num,seed)
+
+        # Figure out which ones are actually worth building stamps for:
+        skip = np.ones(self.nobjects, dtype=bool)
+        stamp_world_pos = []  # Keep track of the world_pos values.
+        print('config = ',galsim.config.CleanConfig(config))
+        for k in range(self.nobjects):
+            base['obj_num'] = obj_num + k
+            pos = galsim.config.ParseWorldPos(config, 'world_pos', base, logger)
+            stamp_world_pos.append(pos)
+            print('pos = ',pos.ra.deg,pos.dec.deg)
+
+            # Trivial check first.
+            if pos.ra.deg < min_ra: continue
+            if pos.ra.deg > max_ra: continue
+            if pos.dec.deg < min_dec: continue
+            if pos.dec.deg > max_dec: continue
+            print('passed trivial checks')
+
+            # Now a more careful check if it is really in the polygon.
+            # Check if it is on the same side of all four (directed) edges.
+            # Note: The WCS may or may not include a flip, so we don't know whether these
+            # should all the left or right.
+            lefts = [self._leftside(pos, p1, p2) for p1,p2 in edges]
+            print('lefts = ',lefts)
+            if len(set(lefts)) == 2: continue
+            print('all left or all right')
+
+            # OK.  This one is close enough to generate the stamp.
+            skip[k] = False
+
+        # Write the stamp-level world_pos to just read off values from the list.
+        base['stamp']['world_pos'] = {
+            'type' : 'List',
+            'items' : stamp_world_pos
+        }
+
+        # Tell the stamp builder which items to trivially skip.
+        base['stamp']['quick_skip'] = {
+            'type' : 'List',
+            'items' : skip
+        }
+        print('stamp.world_pos = ',stamp_world_pos)
+        print('quick_skip = ',skip)
+
+        # The rest of this just copies from the normal Scattered buildImage function
+        stamps, current_vars = galsim.config.stamp.BuildStamps(
+                self.nobjects, base, logger=logger, obj_num=obj_num, do_noise=False)
+
+        base['index_key'] = 'image_num'
+
+        for stamp in stamps:
+            # This is our signal that the object was skipped.
+            if stamp is None: continue
+            bounds = stamp.bounds & image.bounds
+            logger.debug('image %d: full bounds = %s',image_num,str(image.bounds))
+            logger.debug('image %d: stamp bounds = %s',image_num,str(stamp.bounds))
+            logger.debug('image %d: Overlap = %s',image_num,str(bounds))
+            if bounds.isDefined():
+                image[bounds] += stamp[bounds]
+            else:
+                logger.info(
+                    "Object centered at (%d,%d) is entirely off the main image, "
+                    "whose bounds are (%d,%d,%d,%d)."%(
+                        stamp.center.x, stamp.center.y,
+                        image.bounds.xmin, image.bounds.xmax,
+                        image.bounds.ymin, image.bounds.ymax))
+
+        # Bring the image so far up to a flat noise variance
+        current_var = galsim.config.FlattenNoiseVariance(
+                base, image, stamps, current_vars, logger)
+
+        return image, current_var
+
+    @staticmethod
+    def _leftside(pos, p1, p2):
+        # Check if pos is to the left of the directed edge from p1 to p2.
+        # i.e. whether (p1 x p2) . pos is positive.
+        # This is calculated efficiently by the _triple method of CelestialCoord
+        pos._set_aux()
+        p1._set_aux()
+        p2._set_aux()
+        return pos._triple(p2,p1)
+
+    def add_border(self, pos, center, border):
+        """Extend the great circle from ``center`` -> ``pos`` by and additional angle ``border``.
+        """
+        
+        # Define u = pos
+        #        v = center
+        #        w = (u x v) x u
+        # The great circle through u and v is then
+        #
+        #   R(t) = u cos(t) + w sin(t)
+        #
+        # We want the point at R(-border)
+        pos._set_aux()
+        center._set_aux()
+        dsq = (pos._x-center._x)**2 + (pos._y-center._y)**2 + (pos._z-center._z)**2
+
+        # These are unnormalized yet.
+        wx = center._x - pos._x + pos._x * dsq/2.
+        wy = center._y - pos._y + pos._y * dsq/2.
+        wz = center._z - pos._z + pos._z * dsq/2.
+
+        # Normalize
+        wr = (wx**2 + wy**2 + wz**2)**0.5
+        wx /= wr
+        wy /= wr
+        wz /= wr
+
+        # R(-border)
+        s, c = border.sincos()
+        rx = pos._x * c - wx * s
+        ry = pos._y * c - wy * s
+        rz = pos._z * c - wz * s
+        return coord.CelestialCoord.from_xyz(rx,ry,rz)
+
+
+galsim.config.RegisterImageType('WideScattered', WideScatteredBuilder())

--- a/galsim_extra/wide_scattered.py
+++ b/galsim_extra/wide_scattered.py
@@ -17,7 +17,7 @@ class WideScatteredBuilder(galsim.config.image_scattered.ScatteredImageBuilder):
         # Copy the Scattered buildImage function, but with changes to skip building stamps that
         # are clearly not in the image.
 
-        print('start buildImage')
+        #print('start buildImage')
         xsize = base['image_xsize']
         ysize = base['image_ysize']
         wcs = base['wcs']
@@ -56,20 +56,20 @@ class WideScatteredBuilder(galsim.config.image_scattered.ScatteredImageBuilder):
         lr = wcs.toWorld(galsim.PositionD(image.xmax, image.ymin))  # lower-right
         ur = wcs.toWorld(galsim.PositionD(image.xmax, image.ymax))  # upper-right
         cen = wcs.toWorld(image.true_center)
-        print('ll = ',ll)
-        print('ul = ',ul)
-        print('lr = ',lr)
-        print('ur = ',ur)
+        #print('ll = ',ll)
+        #print('ul = ',ul)
+        #print('lr = ',lr)
+        #print('ur = ',ur)
 
         # Push all the corners out by a distance of border
         ll = ll.greatCirclePoint(cen, -border * coord.arcsec)
         ul = ul.greatCirclePoint(cen, -border * coord.arcsec)
         lr = lr.greatCirclePoint(cen, -border * coord.arcsec)
         ur = ur.greatCirclePoint(cen, -border * coord.arcsec)
-        print('ll => ',ll)
-        print('ul => ',ul)
-        print('lr => ',lr)
-        print('ur => ',ur)
+        #print('ll => ',ll)
+        #print('ul => ',ul)
+        #print('lr => ',lr)
+        #print('ur => ',ur)
 
         # Directed edges going around the perimeter
         edges = ( (ll,ul), (ul,ur), (ur,lr), (lr,ll) )
@@ -79,8 +79,8 @@ class WideScatteredBuilder(galsim.config.image_scattered.ScatteredImageBuilder):
         max_ra = max([ll.ra.deg, ul.ra.deg, lr.ra.deg, ur.ra.deg])
         min_dec = min([ll.dec.deg, ul.dec.deg, lr.dec.deg, ur.dec.deg])
         max_dec = max([ll.dec.deg, ul.dec.deg, lr.dec.deg, ur.dec.deg])
-        print('ra range = ',min_ra,max_ra)
-        print('dec range = ',min_dec,max_dec)
+        #print('ra range = ',min_ra,max_ra)
+        #print('dec range = ',min_dec,max_dec)
 
         # Set up rng.
         # Note: This uses the rng of the first object.  Not switching each time.
@@ -93,28 +93,28 @@ class WideScatteredBuilder(galsim.config.image_scattered.ScatteredImageBuilder):
         # Figure out which ones are actually worth building stamps for:
         skip = np.ones(self.nobjects, dtype=bool)
         stamp_world_pos = []  # Keep track of the world_pos values.
-        print('config = ',galsim.config.CleanConfig(config))
+        #print('config = ',galsim.config.CleanConfig(config))
         for k in range(self.nobjects):
             base['obj_num'] = obj_num + k
             pos = galsim.config.ParseWorldPos(config, 'world_pos', base, logger)
             stamp_world_pos.append(pos)
-            print('pos = ',pos.ra.deg,pos.dec.deg)
+            #print('pos = ',pos.ra.deg,pos.dec.deg)
 
             # Trivial check first.
             if pos.ra.deg < min_ra: continue
             if pos.ra.deg > max_ra: continue
             if pos.dec.deg < min_dec: continue
             if pos.dec.deg > max_dec: continue
-            print('passed trivial checks')
+            #print('passed trivial checks')
 
             # Now a more careful check if it is really in the polygon.
             # Check if it is on the same side of all four (directed) edges.
             # Note: The WCS may or may not include a flip, so we don't know whether these
             # should all the left or right.
             lefts = [self._leftside(pos, p1, p2) for p1,p2 in edges]
-            print('lefts = ',lefts)
+            #print('lefts = ',lefts)
             if len(set(lefts)) == 2: continue
-            print('all left or all right')
+            #print('all left or all right')
 
             # OK.  This one is close enough to generate the stamp.
             skip[k] = False
@@ -130,8 +130,8 @@ class WideScatteredBuilder(galsim.config.image_scattered.ScatteredImageBuilder):
             'type' : 'List',
             'items' : skip
         }
-        print('stamp.world_pos = ',stamp_world_pos)
-        print('quick_skip = ',skip)
+        #print('stamp.world_pos = ',stamp_world_pos)
+        #print('quick_skip = ',skip)
 
         # The rest of this just copies from the normal Scattered buildImage function
         stamps, current_vars = galsim.config.stamp.BuildStamps(
@@ -175,7 +175,7 @@ class WideScatteredBuilder(galsim.config.image_scattered.ScatteredImageBuilder):
     def add_border(self, pos, center, border):
         """Extend the great circle from ``center`` -> ``pos`` by and additional angle ``border``.
         """
-        
+
         # Define u = pos
         #        v = center
         #        w = (u x v) x u

--- a/tests/focal_quick.yaml
+++ b/tests/focal_quick.yaml
@@ -280,7 +280,6 @@ input:
         units: arcsec
         grid_spacing: 10
         ngrid: '$math.ceil(2*focal_rmax / @input.power_spectrum.grid_spacing)'
-        center: 0,0
         variance: '$rms_e**2'  # rms_e is given in meta_params
 
     catalog:
@@ -339,7 +338,11 @@ output:
 
             obj_type: '@current_obj_type'
             obj_type_index: '@current_obj_type_index'
-            flux: "$(@current_obj).flux"
+
+            # Not sure why float is needed here.  Sometimes it comes back as a float, other times
+            # as a np.float64, and GalSim complains that the types don't match.  So just always
+            # cast it to float.
+            flux: "$float((@current_obj).flux)"
             shear_g1: stamp.shear.g1
             shear_g2: stamp.shear.g2
 

--- a/tests/focal_quick.yaml
+++ b/tests/focal_quick.yaml
@@ -280,7 +280,7 @@ image:
         dvdy: 0.26
         units: arcsec
         ra: '$19.3 * galsim.hours + chip_num * 10.8 * galsim.arcmin'
-        dec: -33.1 degrees
+        dec: '$-33.1 * galsim.degrees + exp_num * galsim.arcmin'
 
 input:
     # Use analytic galaxies with size and flux parameters that match the distribution seen

--- a/tests/focal_quick.yaml
+++ b/tests/focal_quick.yaml
@@ -333,6 +333,9 @@ output:
             x: "$image_pos.x"
             y: "$image_pos.y"
 
+            ra: "$(@image.world_pos).ra.deg"
+            dec: "$(@image.world_pos).dec.deg"
+
             psf_fwhm: psf.fwhm
             psf_e1: '$(@psf.ellip).e1'
             psf_e2: '$(@psf.ellip).e2'

--- a/tests/focal_quick.yaml
+++ b/tests/focal_quick.yaml
@@ -254,13 +254,14 @@ image:
             #items:
             #- { type: Catalog, col: 1, index_key: exp_num }
             #- "$chip_num + 1"
+        index_key: chip_num
         type: Tan
         dudx: 0.26
         dudy: 0.
         dvdx: 0.
         dvdy: 0.26
         units: arcsec
-        ra: 19.3 hours
+        ra: '$19.3 * galsim.hours + chip_num * 10.8 * galsim.arcmin'
         dec: -33.1 degrees
 
 input:

--- a/tests/focal_quick.yaml
+++ b/tests/focal_quick.yaml
@@ -119,8 +119,8 @@ bright_gal:
             ellip: '@bright_gal.items.1.ellip'
     flux:
         type: Eval
-        # Scale flux up by a factor of 250
-        str: "250.0 * cosmos_flux"
+        # Scale flux up by a factor of 2500
+        str: "2500.0 * cosmos_flux"
         fcosmos_flux: { type: CosmosFlux }
 
 # Faint galaxies use the same population as the bright sample, but scaled
@@ -218,7 +218,7 @@ image:
 
     # Note: The real distribution of sky levels probably isn't flat.  It's probably bimodal,
     # depending on whether the moon is up.  But this is probably ok for now.
-    sky_level: { type: Random, min: 5000, max: 15000, index_key: exp_num }
+    sky_level: { type: Random, min: 500, max: 1500, index_key: exp_num }
 
     random_seed: 8675309
 
@@ -304,11 +304,11 @@ meta_params:
 output:
     type: FocalPlane
 
-    # The number of exposures to build
     # Note: the FocalPlane output type adds another available index key, exp_num.  This can
     # be used as an index_key instead of the usual file_num, image_num, or obj_num.  You can
     # also access it in eval statements as just exp_num.
-    nexp: 2 #'$(input.catalog).getNObjects()'
+
+    nexp: 2    # The number of exposures to build
 
     nchips: 2  # The number of chips per exposure
 

--- a/tests/focal_quick.yaml
+++ b/tests/focal_quick.yaml
@@ -61,6 +61,24 @@ eval_variables:
         - '$(@nearby_gal.items.1.ellip).g2'
         index: '@current_obj_type_index'
 
+    fbulge_frac:
+        type: List
+        items:
+        - 0.
+        - '@bright_gal.items.0.flux'
+        - '@faint_gal.items.0.flux'
+        - '@nearby_gal.items.0.flux'
+        index: '@current_obj_type_index'
+
+    fdisk_smooth_frac:
+        type: List
+        items:
+        - 0.
+        - '@bright_gal.items.1.flux'
+        - '@faint_gal.items.1.flux'
+        - '@nearby_gal.items.1.flux'
+        index: '@current_obj_type_index'
+
 
 # We have several different kinds of objects that we draw.
 #
@@ -355,4 +373,5 @@ output:
             bulge_g2: '$bulge_g2'
             disk_g1: '$disk_g1'
             disk_g2: '$disk_g2'
-
+            bulge_frac: '$bulge_frac'
+            smooth_frac: '$disk_smooth_frac'

--- a/tests/test_cosmos.py
+++ b/tests/test_cosmos.py
@@ -22,8 +22,8 @@ BASE_CONFIG={
                      'nobjects' : 100,
                      'nfiles' : 1,
                      'nstamps_per_object' : 1,
-                     'file_name' : "meds_%d.fits"%0,
-                     'truth': {'file_name' : "truth_%d.dat"%0,
+                     'file_name' : "output/meds_%d.fits"%0,
+                     'truth': {'file_name' : "output/truth_%d.dat"%0,
                                'columns' : {'num': 'obj_num', 'hlr':'$(@gal.half_light_radius)'}}
                    },
         'input' : { 'cosmos_sampler' : { 'min_r50' : 0.15, 'max_r50' : 1., 'min_flux' : 2.5, 'max_flux' : 100 }}
@@ -70,7 +70,7 @@ def test_truth():
 
     #Now run the original config after changing the truth file_name
     i_run=1
-    config['output']['truth']['file_name'] = "truth_%d.dat"%i_run
+    config['output']['truth']['file_name'] = "output/truth_%d.dat"%i_run
     galsim.config.Process(config, logger=logger)
     truth_data_1 = np.loadtxt(config['output']['truth']['file_name'])
     np.testing.assert_array_equal(truth_data_0, truth_data_1)

--- a/tests/test_focalplane.py
+++ b/tests/test_focalplane.py
@@ -14,7 +14,7 @@ def test_truth():
     if __name__ == '__main__':
         logger.setLevel(logging.DEBUG)
 
-    galsim.config.Process(config, logger=logger)
+    galsim.config.Process(config, logger=logger, except_abort=True)
 
     exp_data_list = []
     for exp in range(2):

--- a/tests/test_focalplane.py
+++ b/tests/test_focalplane.py
@@ -22,7 +22,8 @@ def test_truth():
         data_list = []
         for truth_file in truth_files:
             print(truth_file)
-            data = np.genfromtxt(os.path.join('output',truth_file), names=True, dtype=None)
+            data = np.genfromtxt(os.path.join('output',truth_file), names=True, dtype=None,
+                                 encoding='ascii')
             print('file %s = '%truth_file, data)
             data_list.append(data)
         exp_data_list.append(data_list)

--- a/tests/test_focalplane.py
+++ b/tests/test_focalplane.py
@@ -14,6 +14,10 @@ def test_truth():
     if __name__ == '__main__':
         logger.setLevel(logging.DEBUG)
 
+    # Turn off the dithering for this test.
+    config['image']['wcs']['ra'] = '19.3 hours'
+    config['image']['wcs']['dec'] = '-33.1 degrees'
+
     galsim.config.Process(config, logger=logger, except_abort=True)
 
     exp_data_list = []

--- a/tests/test_wide.py
+++ b/tests/test_wide.py
@@ -10,8 +10,8 @@ def test_wide():
 
     config = galsim.config.ReadConfig('focal_quick.yaml')[0]
     config['image']['type'] = 'WideScattered'
-    config['output']['file_name']['format'] = "widesim_%s_%02d.fits.fz"
-    config['output']['truth']['file_name']['format'] = "widetruth_%s_%02d.dat"
+    config['output']['file_name']['format'] = "widesim1_%s_%02d.fits.fz"
+    config['output']['truth']['file_name']['format'] = "widetruth1_%s_%02d.dat"
 
     # The image.world_pos doesn't actually record the right thing in WideScattered.
     # The stamp.world_pos is where the correct ra, dec are stored for each object.
@@ -22,8 +22,6 @@ def test_wide():
     logger.addHandler(logging.StreamHandler(sys.stdout))
     if __name__ == '__main__':
         logger.setLevel(logging.DEBUG)
-        del config['image']['sky_level']  # These are the slowest bits, so remove them to`
-        del config['image']['noise']      # speed up the tests when run on travis.
     else:
         del config['image']['sky_level']  # These are the slowest bits, so remove them to`
         del config['image']['noise']      # speed up the tests when run on travis.
@@ -37,7 +35,7 @@ def test_wide():
     # since the random number generators are used differently and get into different states
     # in the two cases.  So for now, just check that the number of objects in each case comes
     # out right.  This is specific to this particular seed value.
-    cats = [ galsim.Catalog('output/widetruth_DECam_exp%d_%02d.dat'%(i+1,j+1))
+    cats = [ galsim.Catalog('output/widetruth1_DECam_exp%d_%02d.dat'%(i+1,j+1))
              for i in range(2) for j in range(2) ]
     print([cat.nobjects for cat in cats])
     assert cats[0].nobjects == 5   # The first exposures gets nobjects = 12, split over 2 chips
@@ -45,6 +43,81 @@ def test_wide():
     assert cats[2].nobjects == 13  # The second exposure gets nobjects = 19, split over 2 chips
     assert cats[3].nobjects == 6
 
+def test_wide_nonrandom():
+    # The random world_pos is what makes it hard to test the comparison between WideScattered
+    # and Scattered.  So run a version that gets the ra, dec from a pre-determined list of
+    # positions.
+    # Also run these with a much larger area so the tests in Wide make a bigger difference.
+
+    # Generate random ra, dec
+    nobj = 2000
+    ud = galsim.UniformDeviate(1234)
+    ra = np.empty(nobj)
+    dec = np.empty(nobj)
+    ud.generate(ra)
+    ud.generate(dec)
+
+    # Range = 1 degree in each direction, centered at 19.3h, -33.1d
+    ra *= 2
+    ra += 19.3 * 15. - 1
+    dec *= 2
+    dec += -33.1 - 1
+
+    # First run the regular Scattered, but have the input positions be from a much larger area.
+    config = galsim.config.ReadConfig('focal_quick.yaml')[0]
+    config['output']['file_name']['format'] = "widesim2_%s_%02d.fits.fz"
+    config['output']['truth']['file_name']['format'] = "widetruth2_%s_%02d.fits"
+
+    config['image']['world_pos']['ra'] = {
+        'type' : 'Deg',
+        'theta' : { 'type' : 'List', 'items' : ra }
+    }
+    config['image']['world_pos']['dec'] = {
+        'type' : 'Deg',
+        'theta' : { 'type' : 'List', 'items' : dec }
+    }
+    config['image']['nobjects'] = nobj
+
+    del config['image']['sky_level']  # These are the slowest bits, so remove them to speed up this
+    del config['image']['noise']      # and accentuate the difference we are looking for.
+
+    config1 = galsim.config.CopyConfig(config)
+
+    logger = logging.getLogger('test_wide')
+    logger.addHandler(logging.StreamHandler(sys.stdout))
+    #logger.setLevel(logging.DEBUG)
+
+    t0 = time.time()
+    galsim.config.Process(config1, logger=logger, except_abort=True)
+    t1 = time.time()
+    print('Done normal Scattered processing: t = ',t1-t0)
+
+    # Repeat with WideScattered, but use the truth catalog rather than random numbers.
+    config['image']['type'] = 'WideScattered'
+    config['output']['file_name']['format'] = "widesim3_%s_%02d.fits.fz"
+    config['output']['truth']['file_name']['format'] = "widetruth3_%s_%02d.fits"
+    config['output']['truth']['columns']['ra'] = "$(@stamp.world_pos).ra.deg"
+    config['output']['truth']['columns']['dec'] = "$(@stamp.world_pos).dec.deg"
+
+    t2 = time.time()
+    galsim.config.Process(config, logger=logger, except_abort=True)
+    t3 = time.time()
+    print('Done WideScattered processing: t = ',t3-t2)
+
+    for i in range(1,3):
+        for j in range(1,3):
+            im1 = galsim.fits.read('output/widesim2_DECam_exp%d_%02d.fits.fz'%(i,j))
+            im2 = galsim.fits.read('output/widesim3_DECam_exp%d_%02d.fits.fz'%(i,j))
+            np.testing.assert_equal(im1.array, im2.array)
+
+            cat1 = galsim.Catalog('output/widetruth2_DECam_exp%d_%02d.fits'%(i,j))
+            cat2 = galsim.Catalog('output/widetruth3_DECam_exp%d_%02d.fits'%(i,j))
+            assert cat1.nobjects == cat2.nobjects
+            assert cat1.ncols == cat2.ncols
+            assert cat1.names == cat2.names
+            np.testing.assert_equal(cat1.data, cat2.data)
+
 
 if __name__ == '__main__':
     test_wide()
+    test_wide_nonrandom()

--- a/tests/test_wide.py
+++ b/tests/test_wide.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+import galsim
+import logging
+import numpy as np
+import os, sys, time
+
+def test_wide():
+
+    # Start by running focal_quick, but changing the image type to "WideScattered"
+
+    config = galsim.config.ReadConfig('focal_quick.yaml')[0]
+    config['image']['type'] = 'WideScattered'
+    config['output']['file_name']['format'] = "widesim_%s_%02d.fits.fz"
+    config['output']['truth']['file_name']['format'] = "widetruth_%s_%02d.dat"
+
+    # The image.world_pos doesn't actually record the right thing in WideScattered.
+    # The stamp.world_pos is where the correct ra, dec are stored for each object.
+    config['output']['truth']['columns']['ra'] = "$(@stamp.world_pos).ra.deg"
+    config['output']['truth']['columns']['dec'] = "$(@stamp.world_pos).dec.deg"
+
+    logger = logging.getLogger('test_wide')
+    logger.addHandler(logging.StreamHandler(sys.stdout))
+    if __name__ == '__main__':
+        logger.setLevel(logging.DEBUG)
+        del config['image']['sky_level']  # These are the slowest bits, so remove them to`
+        del config['image']['noise']      # speed up the tests when run on travis.
+    else:
+        del config['image']['sky_level']  # These are the slowest bits, so remove them to`
+        del config['image']['noise']      # speed up the tests when run on travis.
+
+    t0 = time.time()
+    galsim.config.Process(config, logger=logger, except_abort=True)
+    t1 = time.time()
+    print('Done Wide processing: t = ',t1-t0)
+
+    # I couldn't figure out a nice way to compare the above to an equivalent non-Wide run,
+    # since the random number generators are used differently and get into different states
+    # in the two cases.  So for now, just check that the number of objects in each case comes
+    # out right.  This is specific to this particular seed value.
+    cats = [ galsim.Catalog('output/widetruth_DECam_exp%d_%02d.dat'%(i+1,j+1))
+             for i in range(2) for j in range(2) ]
+    print([cat.nobjects for cat in cats])
+    assert cats[0].nobjects == 5   # The first exposures gets nobjects = 12, split over 2 chips
+    assert cats[1].nobjects == 7
+    assert cats[2].nobjects == 13  # The second exposure gets nobjects = 19, split over 2 chips
+    assert cats[3].nobjects == 6
+
+
+if __name__ == '__main__':
+    test_wide()


### PR DESCRIPTION
@NiallMac was finding that his simulations were too slow when most of the objects were off the image (because he has a scene that extends over a full focal plane, so most objects miss any given image).  

There is already an `OffChip` type to skip these before doing much work, but this happens after the rng setup and (critically for Niall's sims using a pixmappy wcs) after the determination of the stamp size and location in image coordinates.  So it was still very slow.

This PR adds a new image type, called WideScattered, which works just like Scattered, except that it generates all the world_pos values as part of the image setup and checks whether it is more than an arcmin (by default -- cf. border parameter) off the image being worked on.  If so, it tells the stamp builder to "quick_skip" it.  

This is a new feature in the `quick_skip` branch of GalSim. So for now, this class requires installing that branch, not the current release version of GalSim.  It will be incorporated into GalSim version 2.2.

One caveat about the use of this class is that it reads `image.world_pos` and then writes all the realized world_pos values into a `stamp.world_pos`.  So the latter is the one that has all the correct world positions if you want to write them out into a truth catalog.  I.e. use `stamp.world_pos.ra` rather than `image.world_pos.ra` in the truth catalog column specifications.