### PR TITLE
add obj_type computation

### DIFF
--- a/galsim_extra/wide_scattered.py
+++ b/galsim_extra/wide_scattered.py
@@ -114,6 +114,7 @@ class WideScatteredBuilder(galsim.config.image_scattered.ScatteredImageBuilder):
         #print('config = ',galsim.config.CleanConfig(config))
         for k in range(self.nobjects):
             base['obj_num'] = obj_num + k
+            obj_type, _ = galsim.config.ParseValue(base["stamp"], "obj_type", base, str)  # manually computing this ensures that we have @stamp.obj_type available for computing appropriate world_pos in the image
             pos = galsim.config.ParseWorldPos(config, 'world_pos', base, logger)
             #wrap the ra using the same center as we did
             #for the chip corners, and use this wrapped versions


### PR DESCRIPTION
Manually computing `obj_type` ensures that we have `@stamp.obj_type` available for computing appropriate `world_pos` in the image

in the following image examples, stars are circled in red. without the change, the galaxies are either never drawn or are not being drawn at the correct positions. after the change, both stars and galaxies are drawn at the correct positions

before
![image](https://github.com/esheldon/galsim_extra/assets/26752606/a36334e6-192f-42af-9056-d6c95ffdaf6a)

after
![image](https://github.com/esheldon/galsim_extra/assets/26752606/9166b462-b87d-41cd-b812-eb379f7f6507)

